### PR TITLE
Linting check of use of string join() with generator expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ a linter for pandas usage, please see [pandas-vet](https://github.com/deppen8/pa
 | PDF021 | found 'np.bool' or 'np.object' (use 'np.bool_' or 'np.object_' instead) |
 | PDF022 | found import from 'numpy.random'                                        |
 | PDF023 | found assignment to single-letter variable                              |
+| PDF024 | found string join() with generator expressions                          |
 ## contributing
 
 See `contributing.md` for how to get started.

--- a/pandas_dev_flaker/_ast_helpers.py
+++ b/pandas_dev_flaker/_ast_helpers.py
@@ -42,7 +42,7 @@ def is_str_constant(
             and isinstance(node.func.value, ast.Str)
         )
         or (
-            sys.version_info[0:2] >= (3, 8)
+            sys.version_info >= (3, 8)
             and isinstance(node.func.value, ast.Constant)
             and isinstance(node.func.value.value, str)
         )

--- a/pandas_dev_flaker/_ast_helpers.py
+++ b/pandas_dev_flaker/_ast_helpers.py
@@ -1,4 +1,5 @@
 import ast
+import sys
 from typing import Container, Dict, Sequence, Set
 
 
@@ -28,5 +29,20 @@ def check_for_wrong_alias(
     for name_ in names:
         if name_.name == name:
             return name_.asname != alias
+    else:
+        return False
+
+
+def is_str_constant(
+    node: ast.Call,
+) -> bool:
+    if isinstance(node.func, ast.Attribute):
+        if sys.version_info.major == 3 and sys.version_info.minor < 8:
+            return isinstance(node.func.value, ast.Str)
+        else:
+            return isinstance(node.func.value, ast.Constant) and isinstance(
+                node.func.value.value,
+                str,
+            )
     else:
         return False

--- a/pandas_dev_flaker/_ast_helpers.py
+++ b/pandas_dev_flaker/_ast_helpers.py
@@ -38,7 +38,7 @@ def is_str_constant(
 ) -> bool:
     return isinstance(node.func, ast.Attribute) and (
         (
-            sys.version_info[0:2] < (3, 8)
+            sys.version_info < (3, 8)
             and isinstance(node.func.value, ast.Str)
         )
         or (

--- a/pandas_dev_flaker/_ast_helpers.py
+++ b/pandas_dev_flaker/_ast_helpers.py
@@ -36,13 +36,13 @@ def check_for_wrong_alias(
 def is_str_constant(
     node: ast.Call,
 ) -> bool:
-    python_version = float(sys.version_info.major) + 0.1 * float(
-        sys.version_info.minor,
-    )
     return isinstance(node.func, ast.Attribute) and (
-        (python_version < 3.8 and isinstance(node.func.value, ast.Str))
+        (
+            sys.version_info[0:2] < (3, 8)
+            and isinstance(node.func.value, ast.Str)
+        )
         or (
-            python_version >= 3.8
+            sys.version_info[0:2] >= (3, 8)
             and isinstance(node.func.value, ast.Constant)
             and isinstance(node.func.value.value, str)
         )

--- a/pandas_dev_flaker/_ast_helpers.py
+++ b/pandas_dev_flaker/_ast_helpers.py
@@ -36,13 +36,14 @@ def check_for_wrong_alias(
 def is_str_constant(
     node: ast.Call,
 ) -> bool:
-    if isinstance(node.func, ast.Attribute):
-        if sys.version_info.major == 3 and sys.version_info.minor < 8:
-            return isinstance(node.func.value, ast.Str)
-        else:
-            return isinstance(node.func.value, ast.Constant) and isinstance(
-                node.func.value.value,
-                str,
-            )
-    else:
-        return False
+    python_version = float(sys.version_info.major) + 0.1 * float(
+        sys.version_info.minor,
+    )
+    return isinstance(node.func, ast.Attribute) and (
+        (python_version < 3.8 and isinstance(node.func.value, ast.Str))
+        or (
+            python_version >= 3.8
+            and isinstance(node.func.value, ast.Constant)
+            and isinstance(node.func.value.value, str)
+        )
+    )

--- a/pandas_dev_flaker/_plugins_tree/generator_join_strings.py
+++ b/pandas_dev_flaker/_plugins_tree/generator_join_strings.py
@@ -1,0 +1,29 @@
+"""
+Based on
+
+https://github.com/asottile/pyupgrade/blob/5fb168667ae73f157dd579344708e1cdfb0c0341/pyupgrade/_plugins/generator_expressions_pep289.py
+"""
+
+import ast
+from typing import Iterator, Tuple
+
+from pandas_dev_flaker._ast_helpers import is_str_constant
+from pandas_dev_flaker._data_tree import State, register
+
+MSG = "PDF024 found string join() with generator expressions"
+
+
+@register(ast.Call)
+def visit_Call(
+    state: State,
+    node: ast.Call,
+    parent: ast.AST,
+) -> Iterator[Tuple[int, int, str]]:
+    if (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "join"
+        and is_str_constant(node)
+        and node.args
+        and isinstance(node.args[0], ast.GeneratorExp)
+    ):
+        yield (node.lineno, node.col_offset, MSG)

--- a/tests/generator_join_strings_test.py
+++ b/tests/generator_join_strings_test.py
@@ -1,0 +1,71 @@
+"""
+Based on
+
+https://github.com/asottile/pyupgrade/blob/5fb168667ae73f157dd579344708e1cdfb0c0341/pyupgrade/_plugins/generator_expressions_pep289.py
+"""
+
+import ast
+import tokenize
+from io import StringIO
+
+import pytest
+
+from pandas_dev_flaker.__main__ import run
+
+
+def results(s):
+    return {
+        "{}:{}: {}".format(*r)
+        for r in run(
+            ast.parse(s),
+            list(tokenize.generate_tokens(StringIO(s).readline)),
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        pytest.param(
+            "''.join([str(i) for i in range(5)])",
+            id="String join() with list comprehension",
+        ),
+        pytest.param(
+            "''.join([\n"
+            "        str(i) for i in range(5)\n"
+            "        ]\n"
+            ")\n",
+            id="String join() with multiline list comprehension",
+        ),
+    ),
+)
+def test_list_comprehensions(source):
+    assert not results(source)
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    (
+        pytest.param(
+            "''.join(str(i) for i in range(5))",
+            "1:0: PDF024 found string join() with generator expressions",
+            id="String join() with generator expression",
+        ),
+        pytest.param(
+            "''.join((str(i) for i in range(5)))",
+            "1:0: PDF024 found string join() with generator expressions",
+            id="String join() with parenthesised generator expression",
+        ),
+        pytest.param(
+            "''.join((\n"
+            "        str(i) for i in range(5)\n"
+            "        )\n"
+            ")\n",
+            "1:0: PDF024 found string join() with generator expressions",
+            id="String join() with multiline generator expression",
+        ),
+    ),
+)
+def test_generator_expressions(source, expected):
+    (result,) = results(source)
+    assert result == expected


### PR DESCRIPTION
As requested in [pandas #42173](https://github.com/pandas-dev/pandas/pull/42173), a linting check of the use of string join() with generator expression is added. 